### PR TITLE
Added functionality to dynamically change the width of individual SortTable columns

### DIFF
--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -253,7 +253,7 @@ local methods = {
 	--- @usage st:SetColumnWidth(2, 65)
 	SetColumnWidth   = function(self, columnNumber, width)
 		self.columns[columnNumber]:SetWidth(width);
-	end
+	end,
 
 	-------------------------------------------------------------
 	--- Sorting Methods

--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -67,6 +67,7 @@ local methods = {
 		end
 
 		for i = 1, #columns do
+			local column = self.columns[i];
 			local columnFrame = columnHeadFrame.columns[i];
 			if not columnHeadFrame.columns[i] then
 				columnFrame = self.stdUi:HighlightButton(columnHeadFrame);
@@ -84,6 +85,12 @@ local methods = {
 				end
 
 				columnHeadFrame.columns[i] = columnFrame;
+
+				-- Add column head reference to it's column
+				column.head = columnFrame;
+
+				-- Create a table of empty column cell references
+				column.cells = {};
 			end
 
 			local align = columns[i].align or 'LEFT';
@@ -112,6 +119,18 @@ local methods = {
 
 			columnFrame:SetHeight(self.rowHeight);
 			columnFrame:SetWidth(columns[i].width);
+
+			--- Set the width of a column
+			--- @usage st.columns[i]:SetWidth(width)
+			function column:SetWidth(width)
+				-- Set the width of the column's head
+				column.head:SetWidth(width);
+
+				-- Set the width of each cell in the column
+				for j = 1, #column.cells do
+					column.cells[j]:SetWidth(width)
+				end
+			end
 		end
 
 		self:SetDisplayRows(self.numberOfRows, self.rowHeight);
@@ -161,6 +180,9 @@ local methods = {
 					cell.text = self.stdUi:FontString(cell, '');
 
 					rowFrame.columns[j] = cell;
+
+					-- Add cell reference to column
+					self.columns[j].cells[i] = cell;
 
 					local align = columnData.align or 'LEFT';
 
@@ -226,6 +248,12 @@ local methods = {
 
 		self:SetAutoHeight();
 	end,
+
+	--- Set the width of a column
+	--- @usage st:SetColumnWidth(2, 65)
+	SetColumnWidth   = function(self, columnNumber, width)
+		self.columns[columnNumber]:SetWidth(width);
+	end
 
 	-------------------------------------------------------------
 	--- Sorting Methods

--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -123,6 +123,9 @@ local methods = {
 			--- Set the width of a column
 			--- @usage st.columns[i]:SetWidth(width)
 			function column:SetWidth(width)
+				-- Update the column's width value
+				column.width = width;
+
 				-- Set the width of the column's head
 				column.head:SetWidth(width);
 


### PR DESCRIPTION
You can use this functionality to update the width of a column. It resizes the column head as well as all the cells in the column. Works perfectly and is optimized for performance. 

There are 2 ways to use this feature:

```
st:SetColumnWidth(2, 65); -- Set the 2nd column to be 65px wide
```

or you can do an object oriented approach

```
st:columns[2]:SetWidth(65); -- Set the 2nd column to be 65px wide
```

Either approach works. The object oriented approach would typically be a bit better and easier to understand in code if you were iterating through the columns to resize all of them.

This feature will make it easier to create other functionality on top of this in the area of dynamically resizing all column widths when resizing the SortTable in a resizable window frame:

```
-- Example: If you were to resize the SortTable after creating it, you need to resize the columns too:

-- Get the table width
local tableWidth = st:GetWidth();

-- Determine the current total width of the columns
local total = 0;
for i=1, #st.columns do 
  total = total + st.columns[i].width;
end

-- Iterate through all columns and resize each one to fit the SortTable
for i=1, #st.columns do 
  st.columns[i]:SetWidth(st.columns[i].width/total*tableWidth);
end
```