### PR TITLE
Added MakeResizable functionality

### DIFF
--- a/StdUi.lua
+++ b/StdUi.lua
@@ -224,3 +224,65 @@ function StdUi:MakeDraggable(frame, handle)
 		end);
 	end
 end
+
+-- Make a frame resizable
+function StdUi:MakeResizable(frame, direction)
+	-- Possible resize directions and handle rotation values
+	local anchorDirections = {
+		["TOP"] = 0,
+		["TOPRIGHT"] = 1.5708,
+		["RIGHT"] = 0,
+		["BOTTOMRIGHT"] = 0,
+		["BOTTOM"] = 0,
+		["BOTTOMLEFT"] = -1.5708,
+		["LEFT"] = 0,
+		["TOPLEFT"] = 3.1416,
+	}
+
+	direction = string.upper(direction);
+
+	-- Return if invalid direction
+	if not anchorDirections[direction] then return false end
+
+	frame:SetResizable(true);
+
+	-- Create the resize anchor
+	local anchor = CreateFrame("Button", nil, frame);
+	anchor:SetPoint(direction, frame, direction);
+
+	-- Attach side anchor to adjacent sides of frame
+	if direction == "TOP" or direction == "BOTTOM" then
+		anchor:SetHeight(self.config.resizeHandle.height);
+		anchor:SetPoint("LEFT", frame, "LEFT", self.config.resizeHandle.width, 0);
+		anchor:SetPoint("RIGHT", frame, "RIGHT", self.config.resizeHandle.width*-1, 0);
+	elseif direction == "LEFT" or direction == "RIGHT" then
+		anchor:SetWidth(self.config.resizeHandle.width);
+		anchor:SetPoint("TOP", frame, "TOP", 0, self.config.resizeHandle.height*-1);
+		anchor:SetPoint("BOTTOM", frame, "BOTTOM", 0, self.config.resizeHandle.height);
+	else
+		-- Set the corner anchor textures
+		anchor:SetNormalTexture(self.config.resizeHandle.texture.normal);
+		anchor:SetHighlightTexture(self.config.resizeHandle.texture.highlight);
+		anchor:SetPushedTexture(self.config.resizeHandle.texture.pushed);
+
+		-- Set size and rotate corner anchor
+		anchor:SetSize(self.config.resizeHandle.width, self.config.resizeHandle.height);
+		anchor:GetNormalTexture():SetRotation(anchorDirections[direction]);
+		anchor:GetHighlightTexture():SetRotation(anchorDirections[direction]);
+		anchor:GetPushedTexture():SetRotation(anchorDirections[direction]);
+	end
+
+	-- Resize anchor click handlers
+	anchor:SetScript("OnMouseDown", function(self, button)
+		if button == "LeftButton" then
+			frame:StartSizing(direction);
+			frame:SetUserPlaced(true);
+		end
+	end)
+	anchor:SetScript("OnMouseUp", function(self, button)
+		if button == "LeftButton" then
+			frame:StopMovingOrSizing();
+		end
+	end)
+end
+

--- a/StdUiConfig.lua
+++ b/StdUiConfig.lua
@@ -65,6 +65,16 @@ function StdUi:ResetConfig()
 
 		tooltip     = {
 			padding = 10
+		},
+
+		resizeHandle = {
+			width = 10,
+			height = 10,
+			texture = {
+				normal = "Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Up",
+				highlight = "Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Up",
+				pushed = "Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Down"
+			}
 		}
 	};
 

--- a/widgets/Window.lua
+++ b/widgets/Window.lua
@@ -30,6 +30,12 @@ function StdUi:Window(parent, width, height, title)
 		self.titlePanel.label:SetText(t);
 	end
 
+	-- Resizable window shortcut
+	function frame:MakeResizable(direction)
+		StdUi:MakeResizable(frame, direction);
+		return frame;
+	end
+
 	return frame;
 end
 


### PR DESCRIPTION
- This adds any frame to be resizable in any of the 8 directions.
- The corners include standard resize handles textures
- top/bottom/left/right no visible handle texture but the handle extends from top of frame to bottom
- Added shortcut function to window widget, since that is 99% of the time the only place someone would need something resizable
- Can do multiple resize directions:
```
StdUi:MakeResizable(myWindow, "BOTTOMLEFT");
StdUi:MakeResizable(myWindow, "BOTTOMRIGHT");
```
or a chainable OO approach
```
myWindow:MakeResizable("BOTTOMLEFT"):MakeResizable("BOTTOMRIGHT");
```

Simple example:

```
StdUi = LibStub('StdUi');

window = StdUi:Window(UIParent, 800, 500, 'Resizable example');
window:SetPoint('CENTER');

StdUi:MakeResizable(window, "BOTTOMRIGHT");
-- or this:
-- window:MakeResizable("BOTTOMRIGHT");
```