### PR TITLE
When a SortTable is resized, now the width of the columns and the num…

### DIFF
--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -229,7 +229,6 @@ local methods = {
 				end
 
 				cell:SetHeight(rowHeight);
-				cell:SetWidth(self.columns[j].width);
 
 				cell.text:SetPoint('TOP', cell, 'TOP', 0, 0);
 				cell.text:SetPoint('BOTTOM', cell, 'BOTTOM', 0, 0);
@@ -652,6 +651,26 @@ local methods = {
 				end
 			end
 		end
+
+		-- When SortTable changes size, resize columns proportionally to their initial width
+		self:SetScript("OnSizeChanged", function(self, width, height)
+			local tableWidth = self:GetWidth();
+			local tableHeight = self:GetHeight();
+
+			-- Determine total width of columns
+			local total = 0;
+			for i=1, #self.columns do
+				total = total + self.columns[i].width;
+			end
+
+			-- Adjust all column widths proportionally
+			for i=1, #self.columns do
+				self.columns[i]:SetWidth(self.columns[i].width/total*tableWidth);
+			end
+
+			-- Set the number of displayed rows according to the new height
+			self:SetDisplayRows(math.floor(tableHeight/self.rowHeight), self.rowHeight);
+		end);
 	end,
 };
 


### PR DESCRIPTION
So this functionality will automatically resize the columns and the number of displayed rows on a SortTable whenever it is resized, for example in the case of resizing a window frame that is is in.

Here is the code example from the wiki for the SortTable, slightly modified to make resizable using the new functionality for that:

```
StdUi = LibStub('StdUi');

window = StdUi:Window(UIParent, 800, 500, 'Auto Sort Table Resizing Test');
window:SetPoint('CENTER');

window:MakeResizable("BOTTOMRIGHT")

local btn = StdUi:Button(window, 100, 24, 'Random Data');
StdUi:GlueTop(btn, window, 0, -40);

local function showTooltip(frame, show, spellId)
	if show then
		GameTooltip:SetOwner(frame);
		GameTooltip:SetPoint('RIGHT');
		GameTooltip:SetSpellByID(spellId)
	else
		GameTooltip:Hide();
	end

end


local data = {};
local cols = {

	{
		name         = 'Index',
		width        = 40,
		align        = 'LEFT',
		index        = 'i',
		format       = 'number',
	},

	{
		name         = 'Spell Id',
		width        = 60,
		align        = 'LEFT',
		index        = 'spellId',
		format       = 'number',
		color        = function(table, value)
			local x = value/200000;
			return {r=x, g=1-x, b=0, a=1};
		end
	},
	{
		name         = 'Text',
		width        = 180,
		align        = 'LEFT',
		index        = 'name',
		format       = 'string',
	},

	{
		name         = 'Icon',
		width        = 40,
		align        = 'LEFT',
		index        = 'icon',
		format       = 'icon',
		sortable     = false,
		events         = {
			OnEnter = function(table, cellFrame, rowFrame, rowData, columnData, rowIndex)
				local cellData = rowData[columnData.index];
				showTooltip(cellFrame, true, rowData.spellId);
				return false;
			end,
			OnLeave = function(rowFrame, cellFrame)
				showTooltip(cellFrame, false);
				return false;
			end
		},
	},
}


st = StdUi:ScrollTable(window, cols, 14, 24);
st:EnableSelection(true);
StdUi:GlueTop(st, window, 0, -100);
StdUi:GlueLeft(st, window, 10, 0);
StdUi:GlueRight(st, window, -10, 0);
StdUi:GlueBottom(st, window, 0, 10);

local function getRandomSpell()
	local name = nil;
	local icon, castTime, minRange, maxRange, spellId;

	while name == nil do
		name, _, icon, castTime, minRange, maxRange, spellId =
		GetSpellInfo(math.random(100, 200000));
	end

	return {
		name = name,
		icon = icon,
		castTime = castTime,
		minRange = minRange,
		maxRange = maxRange,
		spellId = spellId;
	};
end

local function randomizeData()
	local lx = math.random(1000, 6000);
	data = {};

	for i=1, lx do
		local r = getRandomSpell()
		r.i = i;
		tinsert(data, r);
	end

	-- update scroll table data
	st:SetData(data);
end

btn:SetScript('OnClick', randomizeData);
```

What you will see is that as you resize the window the columns widths will resize and the number of displayed rows will also automatically change to accommodate the new SortTable size.

One interesting effect of these few PR's I've made recently is that you might want to reconsider the SortTable instantiation. Currently you do something like this:

`st = StdUi:ScrollTable(window, cols, 14, 24);`

The `14` is specifying the number of rows you want in the SortTable. But with the above PR, you would no longer need to specify that. Instead, the functionality can simply automatically determine the number of rows needed based on the height of the SortTable. Any thoughts on this?
