### PR TITLE
Widget Highlight Color Changing & MarkAsValid Border Color Fix

### DIFF
--- a/StdUi.lua
+++ b/StdUi.lua
@@ -1,4 +1,4 @@
-local MAJOR, MINOR = 'StdUi', 3;
+local MAJOR, MINOR = 'StdUi', 4;
 --- @class StdUi
 local StdUi = LibStub:NewLibrary(MAJOR, MINOR);
 

--- a/StdUi.lua
+++ b/StdUi.lua
@@ -87,7 +87,7 @@ StdUi.SetHighlightBorder = function(self)
 		return
 	end
 
-	local hc = StdUi.config.highlight.color;
+	local hc = self.stdUi.config.highlight.color;
 	if not self.origBackdropBorderColor then
 		self.origBackdropBorderColor = {self:GetBackdropBorderColor()};
 	end

--- a/StdUiUtil.lua
+++ b/StdUiUtil.lua
@@ -34,7 +34,7 @@ StdUi.Util = {
 	editBoxValidator    = function(self)
 		self.value = self:GetText();
 
-		StdUi:MarkAsValid(self, true);
+		self.stdUi:MarkAsValid(self, true);
 		return true;
 	end,
 
@@ -45,14 +45,14 @@ StdUi.Util = {
 		local total, gold, silver, copper, isValid = StdUi.Util.parseMoney(text);
 
 		if not isValid or total == 0 then
-			StdUi:MarkAsValid(self, false);
+			self.stdUi:MarkAsValid(self, false);
 			return false;
 		end
 
 		self:SetText(StdUi.Util.formatMoney(total));
 		self.value = total;
 
-		StdUi:MarkAsValid(self, true);
+		self.stdUi:MarkAsValid(self, true);
 		return true;
 	end,
 
@@ -64,23 +64,23 @@ StdUi.Util = {
 		local value = tonumber(text);
 
 		if value == nil then
-			StdUi:MarkAsValid(self, false);
+			self.stdUi:MarkAsValid(self, false);
 			return false;
 		end
 
 		if self.maxValue and self.maxValue < value then
-			StdUi:MarkAsValid(self, false);
+			self.stdUi:MarkAsValid(self, false);
 			return false;
 		end
 
 		if self.minValue and self.minValue > value then
-			StdUi:MarkAsValid(self, false);
+			self.stdUi:MarkAsValid(self, false);
 			return false;
 		end
 
 		self.value = value;
 
-		StdUi:MarkAsValid(self, true);
+		self.stdUi:MarkAsValid(self, true);
 
 		return true;
 	end,
@@ -92,7 +92,7 @@ StdUi.Util = {
 		local name, _, icon, _, _, _, spellId = GetSpellInfo(text);
 
 		if not name then
-			StdUi:MarkAsValid(self, false);
+			self.stdUi:MarkAsValid(self, false);
 			return false;
 		end
 
@@ -100,7 +100,7 @@ StdUi.Util = {
 		self.value = spellId;
 		self.icon:SetTexture(icon);
 
-		StdUi:MarkAsValid(self, true);
+		self.stdUi:MarkAsValid(self, true);
 		return true;
 	end,
 

--- a/StdUiUtil.lua
+++ b/StdUiUtil.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Util', 7;
+local module, version = 'Util', 8;
 if not StdUi:UpgradeNeeded(module, version) then
 	return
 end

--- a/widgets/Autocomplete.lua
+++ b/widgets/Autocomplete.lua
@@ -14,7 +14,7 @@ StdUi.Util.autocompleteTransformer = function(_, value)
 end
 
 StdUi.Util.autocompleteValidator = function(self)
-	StdUi:MarkAsValid(self, true);
+	self.stdUi:MarkAsValid(self, true);
 	return true;
 end
 
@@ -48,11 +48,11 @@ StdUi.Util.autocompleteItemValidator = function(ac)
 	if itemId then
 		ac.value = itemId;
 		ac:SetText(itemName);
-		StdUi:MarkAsValid(ac, true);
+		self.stdUi:MarkAsValid(ac, true);
 
 		return true;
 	else
-		StdUi:MarkAsValid(ac, false);
+		self.stdUi:MarkAsValid(ac, false);
 		return false;
 	end
 end

--- a/widgets/Autocomplete.lua
+++ b/widgets/Autocomplete.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Autocomplete', 2;
+local module, version = 'Autocomplete', 3;
 if not StdUi:UpgradeNeeded(module, version) then return end;
 
 local TableInsert = tinsert;

--- a/widgets/Button.lua
+++ b/widgets/Button.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Button', 4;
+local module, version = 'Button', 5;
 if not StdUi:UpgradeNeeded(module, version) then return end;
 
 local SquareButtonCoords = {

--- a/widgets/Button.lua
+++ b/widgets/Button.lua
@@ -103,6 +103,7 @@ end
 --- @return Button
 function StdUi:Button(parent, width, height, text, inherit)
 	local button = self:HighlightButton(parent, width, height, text, inherit)
+	button.stdUi = self;
 	button:SetHighlightTexture(nil);
 
 	self:ApplyBackdrop(button);

--- a/widgets/Button.lua
+++ b/widgets/Button.lua
@@ -104,6 +104,7 @@ end
 function StdUi:Button(parent, width, height, text, inherit)
 	local button = self:HighlightButton(parent, width, height, text, inherit)
 	button.stdUi = self;
+
 	button:SetHighlightTexture(nil);
 
 	self:ApplyBackdrop(button);

--- a/widgets/Checkbox.lua
+++ b/widgets/Checkbox.lua
@@ -87,11 +87,13 @@ local CheckboxEvents = {
 function StdUi:Checkbox(parent, text, width, height)
 	local checkbox = CreateFrame('Button', nil, parent);
 	checkbox.stdUi = self;
+
 	checkbox:EnableMouse(true);
 	self:SetObjSize(checkbox, width, height or 20);
 	self:InitWidget(checkbox);
 
 	checkbox.target = self:Panel(checkbox, 16, 16);
+	checkbox.target.stdUi = self;
 	checkbox.target:SetPoint('LEFT', 0, 0);
 
 	checkbox.value = true;

--- a/widgets/Checkbox.lua
+++ b/widgets/Checkbox.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Checkbox', 4;
+local module, version = 'Checkbox', 5;
 if not StdUi:UpgradeNeeded(module, version) then
 	return
 end

--- a/widgets/ColorPicker.lua
+++ b/widgets/ColorPicker.lua
@@ -290,6 +290,7 @@ function StdUi:ColorInput(parent, label, width, height, color)
 	self:InitWidget(button);
 
 	button.target = self:Panel(button, 16, 16);
+	button.target.stdUi = self;
 	button.target:SetPoint('LEFT', 0, 0);
 
 	button.text = self:Label(button, label);
@@ -297,6 +298,9 @@ function StdUi:ColorInput(parent, label, width, height, color)
 	button.text:SetPoint('RIGHT', button, 'RIGHT', -5, 0);
 
 	button.color = {r = 1, g = 1, b = 1, a = 1};
+
+	self:HookDisabledBackdrop(button); --ColorInput has no visual difference when disabled unlike Checkbox
+	self:HookHoverBorder(button);
 
 	for k, v in pairs(ColorInputMethods) do
 		button[k] = v;

--- a/widgets/ColorPicker.lua
+++ b/widgets/ColorPicker.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'ColorPicker', 4;
+local module, version = 'ColorPicker', 5;
 if not StdUi:UpgradeNeeded(module, version) then
 	return
 end


### PR DESCRIPTION
Tested Button, HighlightButton, Checkbox, SliderWithBox, Editbox, NumericBox, Radio, Dropdown, ColorInput.

-Fixed changing highlight color on a new instance of StdUi
-Fixed (Button, Checkbox & Radio) highlight color changing
-Added border highlight to ColorInput making it consistent with Checkbox

Only tested numericBoxValidator. Testing of autocomplete validators would be appreciated.

-MarkAsValid now changes border color back to what it should be (if new instance defined or otherwise)