### PR TITLE
ScrollTable icon color

### DIFF
--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -484,6 +484,9 @@ local methods = {
 
 			if color then
 				cellFrame.text:SetTextColor(color.r, color.g, color.b, color.a);
+				if (format == 'icon') then
+					cellFrame.texture:SetVertexColor(color.r, color.g, color.b, color.a) 
+				end
 			else
 				table.stdUi:SetTextColor(cellFrame.text, 'normal');
 			end


### PR DESCRIPTION
Very small feature added to ScrollTable to make 'icon' elements change vertex color when a 'color' attribute is given (seemed intuitive to me for it to work that way, rather than only working for text)