### PR TITLE
ContextMenu bug fixes

### DIFF
--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -66,7 +66,9 @@ StdUi.ContextMenuMethods = {
 	HookRightClick    = function(self)
 		local parent = self:GetParent();
 		if parent then
-			parent:HookScript('OnMouseUp', ContextMenuOnMouseUp);
+			-- ContextMenuOnMouseUp requires a reference to this menu (self)
+			local menu = self -- don't trust magic variable names
+			parent:HookScript('OnMouseUp', function (_, button) ContextMenuOnMouseUp(menu, button) end);
 		end
 	end,
 

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -9,22 +9,6 @@ if not StdUi:UpgradeNeeded(module, version) then
 	return
 end
 
---- ContextMenuItem Events
-
-local ContextMenuItemOnEnter = function(itemFrame, button)
-	itemFrame.parentContext:CloseSubMenus();
-
-	itemFrame.childContext:ClearAllPoints();
-	itemFrame.childContext:SetPoint('TOPLEFT', itemFrame, 'TOPRIGHT', 0, 0);
-	itemFrame.childContext:Show();
-end
-
-local ContextMenuItemOnMouseUp = function(itemFrame, button)
-	if button == 'LeftButton' and itemFrame.contextMenuData.callback then
-		itemFrame.contextMenuData.callback(itemFrame, itemFrame.parentContext)
-	end
-end
-
 --- ContextMenuEvents
 
 local ContextMenuOnMouseUp = function(self, button)
@@ -43,6 +27,24 @@ local ContextMenuOnMouseUp = function(self, button)
 			self:SetPoint('TOPLEFT', nil, 'BOTTOMLEFT', cursorX, cursorY);
 			self:Show();
 		end
+	end
+end
+
+--- ContextMenuItem Events
+
+local ContextMenuItemOnEnter = function(itemFrame, button)
+	itemFrame.parentContext:CloseSubMenus();
+
+	itemFrame.childContext:ClearAllPoints();
+	itemFrame.childContext:SetPoint('TOPLEFT', itemFrame, 'TOPRIGHT', 0, 0);
+	itemFrame.childContext:Show();
+end
+
+local ContextMenuItemOnMouseUp = function(itemFrame, button)
+	if button == 'LeftButton' and itemFrame.contextMenuData.callback then
+		itemFrame.contextMenuData.callback(itemFrame, itemFrame.parentContext)
+	elseif button == 'RightButton' and itemFrame.mainContext then
+		ContextMenuOnMouseUp(itemFrame.mainContext, button)
 	end
 end
 
@@ -121,14 +123,13 @@ StdUi.ContextMenuMethods = {
 			itemFrame:HookScript('OnEnter', ContextMenuItemOnEnter);
 		end
 
+		-- Always need Right click capability in item frames to close the menu
+		itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
+
 		if data.events then
 			for eventName, eventHandler in pairs(data.events) do
 				itemFrame:SetScript(eventName, eventHandler);
 			end
-		end
-
-		if data.callback then
-			itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
 		end
 
 		if data.custom then

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -100,6 +100,12 @@ StdUi.ContextMenuMethods = {
 
 		itemFrame.contextMenuData = data;
 
+		-- Need mainContext on all items for right click compatibility.
+		-- This will also keep propagating mainContext thru all children.
+		-- Note: In the top-most level of items frames, the parent does NOT have a
+		-- mainContext, and in that case the parent itself IS the mainContext.
+		itemFrame.mainContext = parent.mainContext or parent
+
 		if not data.isSeparator then
 			itemFrame.text:SetJustifyH('LEFT');
 		end
@@ -111,8 +117,6 @@ StdUi.ContextMenuMethods = {
 
 			itemFrame.childContext = parent.stdUi:ContextMenu(parent, data.children, true, parent.level + 1);
 			itemFrame.parentContext = parent;
-			-- this will keep propagating mainContext thru all children
-			itemFrame.mainContext = parent.mainContext;
 
 			itemFrame:HookScript('OnEnter', ContextMenuItemOnEnter);
 		end

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -217,6 +217,9 @@ function StdUi:ContextMenu(parent, options, stopHook, level)
 
 	panel:SetFrameStrata('FULLSCREEN_DIALOG');
 
+	-- force context menus to stay on the screen where they can be used
+	panel:SetClampedToScreen(true)
+
 	for k, v in pairs(self.ContextMenuMethods) do
 		panel[k] = v;
 	end


### PR DESCRIPTION
The ContextMenu widget is totally broken in the current master branch.  Right clicking on a window causes that window itself to `Hide()` rather than showing the ContextMenu as was intended.

There are a few other bugs as well, fixed in this PR.

The net effect of this PR:

- ContextMenu will open correctly
- Right clicking ContextMenu or its items will close ContextMenu

The diffs look much bigger than they really are.  I had to move the ContextMenuItem events below the ContextMenu events, because the ContextMenuItem code needed to invoke the parent menu code to get right-click-closing to work.