### PR TITLE
ContextMenu improvements

### DIFF
--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -66,7 +66,9 @@ StdUi.ContextMenuMethods = {
 	HookRightClick    = function(self)
 		local parent = self:GetParent();
 		if parent then
-			parent:HookScript('OnMouseUp', ContextMenuOnMouseUp);
+			-- ContextMenuOnMouseUp requires a reference to this menu (self)
+			local menu = self -- don't trust magic variable names
+			parent:HookScript('OnMouseUp', function (_, button) ContextMenuOnMouseUp(menu, button) end);
 		end
 	end,
 

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -20,8 +20,14 @@ local ContextMenuItemOnEnter = function(itemFrame, button)
 end
 
 local ContextMenuItemOnMouseUp = function(itemFrame, button)
+	local hide
 	if button == 'LeftButton' and itemFrame.contextMenuData.callback then
-		itemFrame.contextMenuData.callback(itemFrame, itemFrame.parentContext)
+		hide = itemFrame.contextMenuData.callback(itemFrame, itemFrame.parentContext)
+	elseif button == 'RightButton' then
+		hide = true
+	end
+	if hide == true and itemFrame.mainContext then
+		itemFrame.mainContext:Hide()
 	end
 end
 

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -98,6 +98,12 @@ StdUi.ContextMenuMethods = {
 
 		itemFrame.contextMenuData = data;
 
+		-- Need mainContext on all items for right click compatibility.
+		-- This will also keep propagating mainContext thru all children.
+		-- Note: In the top-most level of items frames, the parent does NOT have a
+		-- mainContext, and in that case the parent itself IS the mainContext.
+		itemFrame.mainContext = parent.mainContext or parent
+
 		if not data.isSeparator then
 			itemFrame.text:SetJustifyH('LEFT');
 		end
@@ -109,8 +115,6 @@ StdUi.ContextMenuMethods = {
 
 			itemFrame.childContext = parent.stdUi:ContextMenu(parent, data.children, true, parent.level + 1);
 			itemFrame.parentContext = parent;
-			-- this will keep propagating mainContext thru all children
-			itemFrame.mainContext = parent.mainContext;
 
 			itemFrame:HookScript('OnEnter', ContextMenuItemOnEnter);
 		end

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -127,9 +127,8 @@ StdUi.ContextMenuMethods = {
 			end
 		end
 
-		if data.callback then
-			itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
-		end
+		-- Always need Right click capability in item frames to close the menu
+		itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
 
 		if data.custom then
 			for key, value in pairs(data.custom) do

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -217,6 +217,9 @@ function StdUi:ContextMenu(parent, options, stopHook, level)
 
 	panel:SetFrameStrata('FULLSCREEN_DIALOG');
 
+	-- force context menus to stay on the screen where they can be used
+	panel:SetClampedToScreen(true)
+
 	for k, v in pairs(self.ContextMenuMethods) do
 		panel[k] = v;
 	end


### PR DESCRIPTION
This PR fixes some major bugs with the ContextMenu.

- ContextMenu is now clamped to screen.
- BUGFIX: mainContext is now correctly assigned to menu items.
- BUGFIX: Right click on parent window now correctly opens ContextMenu instead of hiding parent window.
- Right click on any ContextMenu item now closes ContextMenu.
- ContextMenu item callbacks can now optionally return TRUE if they want to close the ContextMenu after the click has been handled.