### PR TITLE
Add StdUi:ScrollingMessageFrame and StdUi:GetFontObject

### DIFF
--- a/StdUi.lua
+++ b/StdUi.lua
@@ -295,3 +295,55 @@ function StdUi:MakeResizable(frame, direction)
 	end)
 end
 
+--- Get a StdUi font object.
+--- This method generates font objects on demand at runtime and caches them for reuse.
+--- Each font is classified by a class and a color code.
+--- Classes are defined by the application via StdUi.config.fontClasses{}. The default class is 'default'.
+--- Color codes are defined by the application via StdUi.config.font.color{}. The default color is 'normal'.
+--- @usage font = StdUi:GetFontObject('scrollingMessage', 'normal')
+--- @usage font = StdUi:GetFontObject('default', 'highlight')
+--- @usage font = StdUi:GetFontObject('default', 'disabled')
+--- @param class string A key of StdUi.config.fontClasses, or 'default'
+--- @param colorCode string A key of StdUi.config.font.color ('normal' by default)
+function StdUi:GetFontObject(class, colorCode)
+	class = class or 'default'
+	colorCode = colorCode or 'normal'
+
+	-- initialize self._RUNTIME_FONTS
+	self._RUNTIME_FONTS = self._RUNTIME_FONTS or {}
+
+	local cacheKey = class ..'/'.. colorCode
+	if self._RUNTIME_FONTS[cacheKey] == nil then
+
+		local defaultFontConfig = self.config.font
+
+		local fontConfig = self.config.font
+		if class ~= 'default' and self.config.fontClasses[class] ~= nil then
+			fontConfig = self.config.fontClasses[class]
+		end
+
+		local family = fontConfig.family or defaultFontConfig.family
+		local size = fontConfig.size or defaultFontConfig.size or 12
+		local flags = fontConfig.effect or defaultFontConfig.effect or ''
+		local color = (fontConfig.color or {})[colorCode] or defaultFontConfig.color[colorCode] or defaultFontConfig.color.normal
+		local justifyH = fontConfig.justifyH or defaultFontConfig.justifyH or 'CENTER'
+		local justifyV = fontConfig.justifyV or defaultFontConfig.justifyV or 'MIDDLE'
+
+		-- CreateFont *requires* a globally unique name for this font
+		-- We won't ever refer to this by its name but we still need to generate a unique name
+
+		local fontFullName = "StdUi Runtime Font "..
+				family .." ".. size .." ".. flags ..";"..
+				color.r ..",".. color.g ..",".. color.b ..":".. color.a ..";"..
+				justifyH .."-".. justifyV
+
+		local font = CreateFont(fontFullName)
+		font:SetFont(family, size, flags)
+		font:SetTextColor(color.r, color.g, color.b, color.a)
+		font:SetJustifyH(justifyH)
+		font:SetJustifyV(justifyV)
+
+		self._RUNTIME_FONTS[cacheKey] = font
+	end
+	return self._RUNTIME_FONTS[cacheKey]
+end

--- a/StdUi.xml
+++ b/StdUi.xml
@@ -18,6 +18,7 @@
 	<Script file="widgets\Autocomplete.lua"/>
 	<Script file="widgets\Label.lua"/>
 	<Script file="widgets\Scroll.lua"/>
+	<Script file="widgets\ScrollingMessage.lua"/>
 	<Script file="widgets\ScrollTable.lua"/>
 	<Script file="widgets\Slider.lua"/>
 	<Script file="widgets\Tooltip.lua"/>

--- a/widgets/ScrollingMessage.lua
+++ b/widgets/ScrollingMessage.lua
@@ -1,0 +1,134 @@
+--- @type StdUi
+local StdUi = LibStub and LibStub('StdUi', true)
+if not StdUi then
+	return
+end
+
+local module, version = 'ScrollingMessage', 1
+if not StdUi:UpgradeNeeded(module, version) then
+	return
+end
+
+----------------------------------------------------
+--- ScrollingMessageFrame
+----------------------------------------------------
+
+StdUi.ScrollingMessageFrameMethods = {
+
+	AddMessage = function(self, ...)
+		-- must check whether we're max scrolled BEFORE we add the new message
+		local wasScrolledToMax = self:IsScrolledToMax()
+		-- parent class AddMessage
+		self:_AddMessage(...)
+		-- Update the number of items
+		local numItems = self.scrollFrame.itemCount or 0
+		-- Cannot have more than GetMaxLines() lines in this ScrollingMessageFrame; place an upper limit
+		numItems = math.min(self:GetMaxLines(), numItems + 1)
+		self.scrollFrame:UpdateItemsCount(numItems)
+		-- If we were scrolled to the end already, then scroll past this new message
+		if wasScrolledToMax then
+			self:ScrollToMax()
+		end
+	end,
+
+	Hide = function(self)
+		self:_Hide()
+		self.scrollFrame:Hide()
+	end,
+
+	IsScrolledToMax = function(self)
+		local _, max = self.scrollFrame.scrollBar:GetMinMaxValues()
+		local scrollValue = self.scrollFrame.scrollBar:GetValue()
+		return scrollValue == max
+	end,
+
+	IsScrolledToMin = function(self)
+		local min = self.scrollFrame.scrollBar:GetMinMaxValues()
+		local scrollValue = self.scrollFrame.scrollBar:GetValue()
+		return scrollValue == min
+	end,
+
+	ScrollToMax = function(self)
+		local _, max = self.scrollFrame.scrollBar:GetMinMaxValues()
+		self.scrollFrame:DoVerticalScroll(max)
+	end,
+
+	ScrollToMin = function(self)
+		local min = self.scrollFrame.scrollBar:GetMinMaxValues()
+		self.scrollFrame:DoVerticalScroll(min)
+	end,
+
+	SetFontObject = function(self, font)
+		self:_SetFontObject(font)
+		-- on setting the font, auto-compute the line height
+		local tmp = self.stdUi:FontString(self, "X")
+		tmp:SetFont(self:GetFont())
+		local lineHeight = math.floor(tmp:GetHeight() + 0.5)
+		self:SetLineHeight(lineHeight)
+	end,
+
+	SetLineHeight = function(self, lineHeight)
+		self.scrollFrame.lineHeight = lineHeight
+		self:UpdateDisplayCount()
+	end,
+
+	SetPoint = function(self, ...)
+		self:_SetPoint(...)
+		if self.scrollFrame then -- this can be called before we have a scrollFrame
+			self.scrollFrame:SetPoint(...)
+		end
+	end,
+
+	SetSize = function(self, width, height)
+		self:_SetSize(width, height)
+		self.scrollFrame:SetSize(width, height)
+		self:UpdateDisplayCount()
+	end,
+
+	Show = function(self)
+		self:_Show()
+		self.scrollFrame:Show()
+	end,
+
+	UpdateDisplayCount = function(self)
+		self.scrollFrame.displayCount = math.floor(self:GetHeight() / self.scrollFrame.lineHeight)
+	end,
+}
+
+function StdUi:ScrollingMessageFrame(parent, width, height)
+
+	local frame = CreateFrame("ScrollingMessageFrame", nil, parent)
+	frame.stdUi = self
+
+	for k, v in pairs(self.ScrollingMessageFrameMethods) do
+		-- if the base object already contains this method, save a reference to it
+		if frame[k] ~= nil then
+			frame["_"..k] = frame[k]
+		end
+		-- override the method
+		frame[k] = v
+	end
+
+	-- passing faux displayCount and lineHeight values to FauxScrollFrame,
+	-- we will keep those dynamically updated so the values passed here don't matter.
+	local scrollFrame = self:FauxScrollFrame(parent, width, height, 0, 0, frame)
+	frame.scrollFrame = scrollFrame
+
+	self:ApplyBackdrop(scrollFrame, 'messages')
+
+	scrollFrame:SetPoint("CENTER")
+
+	frame:SetSize(width, height)
+	frame:SetPoint("CENTER")
+
+	frame:SetMaxLines(100)
+	frame:SetFading(false)
+	frame:SetIndentedWordWrap(true)
+	frame:SetJustifyH("LEFT")
+
+	frame:SetFontObject(self:GetFontObject('messages'))
+
+	return frame
+end
+
+StdUi:RegisterModule(module, version)

--- a/widgets/Window.lua
+++ b/widgets/Window.lua
@@ -11,6 +11,8 @@ if not StdUi:UpgradeNeeded(module, version) then return end;
 function StdUi:Window(parent, width, height, title)
 	parent = parent or UIParent;
 	local frame = self:PanelWithTitle(parent, width, height, title);
+	frame:SetFrameStrata('DIALOG')
+	frame:SetPoint('CENTER');
 	frame:SetClampedToScreen(true);
 	frame.titlePanel.isWidget = false;
 	self:MakeDraggable(frame); -- , frame.titlePanel
@@ -48,8 +50,6 @@ function StdUi:Dialog(title, message, dialogId)
 		window = self.dialogs[dialogId];
 	else
 		window = self:Window(nil, self.config.dialog.width, self.config.dialog.height, title);
-		window:SetPoint('CENTER');
-		window:SetFrameStrata('DIALOG');
 	end
 
 	if window.messageLabel then


### PR DESCRIPTION
The primary purpose of this PR is to add StdUi:ScrollingMessageFrame

In implementing that I needed to be able to easily customize the font in the ScrollingMessageFrame and so I created the optional concept of "font classes" in the StdUi.config.

## Sample usage of `StdUi:ScrollingMessageFrame`

```lua
local window = StdUi:Window(UIParent, 400, 300, "Messages")

local smf = StdUi:ScrollingMessageFrame(window, 392, 260)
StdUi:GlueBottom(smf, window, 0, 4)

for i=1, 10 do
    smf:AddMessage("This is message ".. i)
end
```

The color of the ScrollingMessageFrame panel is optionally configured via the `messages` element of `StdUi.config.backdrop`

```lua
StdUi.config.backdrop.messages = { r=0, g=0, b=0, a=1 }
```

## Font Classes and `StdUi:GetFontObject`

The font used to display the messages can optionally be customized by defining a `messages` font class in `StdUi.config.fontClasses` and overriding any attributes of the default font that are desired.  For example messages are nice to be aligned left in my case.

```lua
StdUi.config.fontClasses = {
    messages = {
        size = 10,
        justifyH = 'LEFT',
    },
}
```

If you don't define the `messages` fontClass (e.g. all previous configs) then it will be the same as the default font.  You don't have to define every aspect of every font class, you must only define those attributes that differ from the `default` fontClass (the one defined by `StdUi.config.font`).

To add new font classes you simply do something like:

```lua
StdUi.config.fontClasses = {
    MY_CUSTOM_CLASS = {
        size = 48,
    },
}
```

Then where you want to use it:

```lua
local font = StdUi:GetFontObject('MY_CUSTOM_CLASS')
```
