### PR TITLE
Added a format time option

### DIFF
--- a/StdUiUtil.lua
+++ b/StdUiUtil.lua
@@ -185,6 +185,23 @@ StdUi.Util = {
 
 		return output:trim();
 	end,
+	
+	formatTime         = function(totalTime)
+		local days = floor(totalTime/86400)
+		local hours = floor(mod(totalTime, 86400)/3600)
+		local minutes = floor(mod(totalTime,3600)/60)
+		local seconds = floor(mod(totalTime,60))
+
+		if (days > 0) then
+			return format("%dd%02dh%02dm%02ds",days,hours,minutes,seconds)
+		elseif (hours > 0) then
+			return format("%02dh%02dm%02ds",hours,minutes,seconds)
+		elseif (minutes > 0) then
+			return format("%02dm%02ds",minutes,seconds)
+		elseif (seconds > 0) then
+			return format("%02ds", seconds)
+		end 
+	end,
 
 	stripColors         = function(text)
 		text = string.gsub(text, '|c%x%x%x%x%x%x%x%x', '');

--- a/StdUiUtil.lua
+++ b/StdUiUtil.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Util', 10;
+local module, version = 'Util', 11;
 if not StdUi:UpgradeNeeded(module, version) then
 	return
 end

--- a/StdUiUtil.lua
+++ b/StdUiUtil.lua
@@ -193,11 +193,11 @@ StdUi.Util = {
 		local seconds = floor(mod(totalTime,60))
 
 		if (days > 0) then
-			return format("%dd%02dh%02dm%02ds",days,hours,minutes,seconds)
+			return format("%dd %02dh %02dm %02ds",days,hours,minutes,seconds)
 		elseif (hours > 0) then
-			return format("%02dh%02dm%02ds",hours,minutes,seconds)
+			return format("%02dh %02dm %02ds",hours,minutes,seconds)
 		elseif (minutes > 0) then
-			return format("%02dm%02ds",minutes,seconds)
+			return format("%02dm %02ds",minutes,seconds)
 		elseif (seconds > 0) then
 			return format("%02ds", seconds)
 		end 

--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'ScrollTable', 6;
+local module, version = 'ScrollTable', 7;
 if not StdUi:UpgradeNeeded(module, version) then
 	return
 end

--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -468,7 +468,7 @@ local methods = {
 			elseif format == 'moneyShort' then
 				value = table.stdUi.Util.formatMoney(value, true);
 				cellFrame.text:SetText(value);
-			elseif format == 'formatTime' then
+			elseif format == 'time' then
 				value = table.stdUi.Util.formatTime(value);
 				cellFrame.text:SetText(value);
 			elseif format == 'number' then

--- a/widgets/ScrollTable.lua
+++ b/widgets/ScrollTable.lua
@@ -468,6 +468,9 @@ local methods = {
 			elseif format == 'moneyShort' then
 				value = table.stdUi.Util.formatMoney(value, true);
 				cellFrame.text:SetText(value);
+			elseif format == 'formatTime' then
+				value = table.stdUi.Util.formatTime(value);
+				cellFrame.text:SetText(value);
 			elseif format == 'number' then
 				value = tostring(value);
 				cellFrame.text:SetText(value);


### PR DESCRIPTION
Hello! While making my addon I needed to add a format into the scroll table to let me format time from second to days/hours/minutes/seconds. So I tought it could be nice to have it officialy in the lib :)

Here is a preview the way it render in a ScrollTable
![Screenshot_31](https://user-images.githubusercontent.com/30201149/154203159-c778d024-0885-40a8-a03f-3878b6768b06.png)
