### PR TITLE
DF 10.0 SetFont() and SetHighlightTexture() arg's must not be nil.

### DIFF
--- a/StdUiConfig.lua
+++ b/StdUiConfig.lua
@@ -22,7 +22,7 @@ function StdUi:ResetConfig()
 			family    = font,
 			size      = fontSize,
 			titleSize = largeFontSize,
-			effect    = 'NONE',
+			effect    = '',
 			strata    = 'OVERLAY',
 			color     = {
 				normal   = { r = 1, g = 1, b = 1, a = 1 },

--- a/widgets/Button.lua
+++ b/widgets/Button.lua
@@ -109,7 +109,7 @@ function StdUi:Button(parent, width, height, text, inherit)
 	local button = self:HighlightButton(parent, width, height, text, inherit)
 	button.stdUi = self;
 
-	button:SetHighlightTexture(nil);
+	button:SetHighlightTexture('');
 
 	self:ApplyBackdrop(button);
 	self:HookDisabledBackdrop(button);


### PR DESCRIPTION
DF 10.0 api's are more strict and generally do not accept nil as a valid argument value.
The font effect, the 3rd arg to SetFont(), does not accept nil or 'NONE' in DF 10.0, but a zero-length string is valid when no font effect is specified.
The texture path arg to Button:SetHighlightTexture()  must not be nil in DF 10.0 but a zero-length string is valid when no texture path is specified.
I tested these 2 changes in DF 10.0.2 Beta, DF 10.0.0 PTR, SL 9.2.7, Wrath Classic 3.4.0 and Classic Era 1.14.3 and the changes are backwards and forwards compatible with no problems.
This resolves the 2 issues #27 and #28 that I raised.
Many thanks for making these changes to keep StdUi working through DF.
Thanks for explaining how to fork the StdUi repo and make a PR to get these changes done.