### PR TITLE
Action Buttons as Context Menu items need to have a Name and a Template

### DIFF
--- a/widgets/Button.lua
+++ b/widgets/Button.lua
@@ -36,8 +36,8 @@ local SquareButtonMethods = {
 	end
 };
 
-function StdUi:SquareButton(parent, width, height, icon)
-	local button = CreateFrame('Button', nil, parent);
+function StdUi:SquareButton(parent, width, height, icon, name)
+	local button = CreateFrame('Button', name, parent);
 	button.stdUi = self;
 
 	self:InitWidget(button);
@@ -85,8 +85,8 @@ end
 
 --- Creates a button with only a highlight
 --- @return Button
-function StdUi:HighlightButton(parent, width, height, text, inherit)
-	local button = CreateFrame('Button', nil, parent, inherit);
+function StdUi:HighlightButton(parent, width, height, text, inherit, name)
+	local button = CreateFrame('Button', name, parent, inherit);
 	self:InitWidget(button);
 	self:SetObjSize(button, width, height);
 	button.text = self:ButtonLabel(button, text);
@@ -105,8 +105,8 @@ function StdUi:HighlightButton(parent, width, height, text, inherit)
 end
 
 --- @return Button
-function StdUi:Button(parent, width, height, text, inherit)
-	local button = self:HighlightButton(parent, width, height, text, inherit)
+function StdUi:Button(parent, width, height, text, inherit, name)
+	local button = self:HighlightButton(parent, width, height, text, inherit, name)
 	button.stdUi = self;
 
 	button:SetHighlightTexture('');

--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -85,7 +85,9 @@ StdUi.ContextMenuMethods = {
 	CreateItem        = function(parent, data, i)
 		local itemFrame;
 
-		if data.title then
+		if data.constructor and type(data.constructor) == 'function' then
+			itemFrame = data.constructor(parent, data, i);
+		elseif data.title then
 			itemFrame = parent.stdUi:Frame(parent, nil, 20);
 			itemFrame.text = parent.stdUi:Label(itemFrame);
 			parent.stdUi:GlueLeft(itemFrame.text, itemFrame, 0, 0, true);
@@ -148,7 +150,9 @@ StdUi.ContextMenuMethods = {
 	UpdateItem        = function(parent, itemFrame, data, i)
 		local padding = parent.padding;
 
-		if data.title then
+		if data.renderer and type(data.renderer) == 'function' then
+			data.renderer(parent, itemFrame, data, i);
+		elseif data.title then
 			itemFrame.text:SetText(data.title);
 			parent.stdUi:ButtonAutoWidth(itemFrame);
 		elseif data.checkbox or data.radio then


### PR DESCRIPTION
A custom constructor & custom renderer are required to construct & update/display SecureActionButtons with a Name and also inherit from SecureActionButtonTemplate, to be used as ContextMenu items which can execute a macro or cast a spell etc.
This is needed to allow a user to quickly execute restricted/protected commands/macros/spells via an easy-to-use popup ContentMenu with Action Buttons in the menu items.
This provides a lot of power to a UI and makes the UI fast and easy to use, in an object-oriented context-sensitive manner.

This resolves Issue #31 