### PR TITLE
Action Buttons in a ContextMenu need the Click to go to the OnClick h…

### DIFF
--- a/widgets/ContextMenu.lua
+++ b/widgets/ContextMenu.lua
@@ -136,7 +136,11 @@ StdUi.ContextMenuMethods = {
 		end
 
 		-- Always need Right click capability in item frames to close the menu
-		itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
+		if data.hookOnClickIndicator then
+			itemFrame:HookScript('OnClick', ContextMenuItemOnMouseUp)
+		else
+			itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
+		end
 
 		if data.custom then
 			for key, value in pairs(data.custom) do


### PR DESCRIPTION
…andler, not the OnMouseUp handler.

Blizzard have changed Action Buttons in Dragonflight Beta so that the Down argument is not passed to its OnClick handler. This is to support the new Press and Hold action button repeated casting implementation. This means that Action Buttons now only work if they register and handle the Up state of the mouse button. That is, itemFrame:RegisterForClicks("LeftButtonUp") for type1 / macrotext1 action button, for example. However, the ContextMenu uses an OnMouseUp handler to intercept the Up mouse click to close a context menu item. The problem is that the OnMouseUp handler *eats* the Action Button Click *before* it gets to the standard Action Button OnClick handler. So the Action Button macro/spell does not get executed and it fails silently. The proposed solution is to set "data.hookOnClickIndicator = true" when defining a menu item which is constructed with a SecureActionButton. The data.hookOnClickIndicator will not be set by any existing addons which use StdUi lib. So this meta-data-driven approach ensures that only new addons which choose to use the custom data.constructor and data.hookOnClickIndicator setting will create custom Action Buttons. This ensures that the Context Menu will Hook the OnClick handler (to receive the Click after the Action Button has executed the macro/spell), instead of Set the OnMouseUp handler (which eats the Click), to close a menu item context.

The proposed coding change to the ContextMenu CreateItem method is simply:

		if data.hookOnClickIndicator then
			itemFrame:HookScript('OnClick', ContextMenuItemOnMouseUp)
		else
			itemFrame:SetScript('OnMouseUp', ContextMenuItemOnMouseUp)
		end

This has been tested with Context Menus which have a mixture of menu item Action Buttons which inherit SecureActionButonTemplate and normal menu item buttons. Both types of menu item buttons co-exist in a ContextMenu and behave as expected, with no side-effects. The change has backwards compatibility with existing addons that use StdUi lib.

This resolves Issue #33
