### PR TITLE
Change FontString:SetJustifyH param from MIDDLE to CENTER

### DIFF
--- a/widgets/Basic.lua
+++ b/widgets/Basic.lua
@@ -27,7 +27,7 @@ function StdUi:PanelWithLabel(parent, width, height, inherits, text)
 
 	frame.label = self:Header(frame, text);
 	frame.label:SetAllPoints();
-	frame.label:SetJustifyH('MIDDLE');
+	frame.label:SetJustifyH('CENTER');
 
 	return frame;
 end

--- a/widgets/Basic.lua
+++ b/widgets/Basic.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Basic', 3;
+local module, version = 'Basic', 4;
 if not StdUi:UpgradeNeeded(module, version) then return end;
 
 function StdUi:Frame(parent, width, height, inherits)

--- a/widgets/ProgressBar.lua
+++ b/widgets/ProgressBar.lua
@@ -58,7 +58,7 @@ function StdUi:ProgressBar(parent, width, height, vertical)
 	end
 
 	progressBar.text = self:Label(progressBar, '');
-	progressBar.text:SetJustifyH('MIDDLE');
+	progressBar.text:SetJustifyH('CENTER');
 	progressBar.text:SetAllPoints();
 
 	self:ApplyBackdrop(progressBar);

--- a/widgets/ProgressBar.lua
+++ b/widgets/ProgressBar.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'ProgressBar', 3;
+local module, version = 'ProgressBar', 4;
 if not StdUi:UpgradeNeeded(module, version) then return end;
 
 ----------------------------------------------------

--- a/widgets/Window.lua
+++ b/widgets/Window.lua
@@ -56,7 +56,7 @@ function StdUi:Dialog(title, message, dialogId)
 		window.messageLabel:SetText(message);
 	else
 		window.messageLabel = self:Label(window, message);
-		window.messageLabel:SetJustifyH('MIDDLE');
+		window.messageLabel:SetJustifyH('CENTER');
 		self:GlueAcross(window.messageLabel, window, 5, -10, -5, 5);
 	end
 

--- a/widgets/Window.lua
+++ b/widgets/Window.lua
@@ -4,7 +4,7 @@ if not StdUi then
 	return
 end
 
-local module, version = 'Window', 5;
+local module, version = 'Window', 6;
 if not StdUi:UpgradeNeeded(module, version) then return end;
 
 --- @return Frame


### PR DESCRIPTION
Blizzard has changed the FontString:SetJustifyH() parameters to strictly enforce only the allowed parameters.
The deprecated 'MIDDLE' parameter to centre FontString text is no longer valid.
This causes a Lua error in Retail 10.2.7 PTR (going live on 7 May 2024) and Cataclysm Classic Pre-Patch (just gone live on 30 April 2024).
The valid parameter for FontString:SetJustifyH() to center some text is now 'CENTER' instead of 'MIDDLE'.
This change does not affect any of the StdUi function interfaces. 
This is an internal implementation change only where generally a Stdui:Label which is being centered as a Panel title.
The change has backwards and forwards compatibility with addons using the StdUi lib in WoW Retail, Classic Era and Cataclysm Classic.